### PR TITLE
Return empty array instead of 404 when a company query has no matches

### DIFF
--- a/backend/src/controllers/companyController.ts
+++ b/backend/src/controllers/companyController.ts
@@ -43,11 +43,6 @@ export const getCompanies = asyncHandler(async (req, res, next) => {
       .exec(),
   ]);
 
-  // Return 404 if no companies are found
-  if (companies.length === 0) {
-    return next(createHttpError(404, "No companies found that satisfy query."));
-  }
-
   res.status(200).json({
     page,
     perPage,


### PR DESCRIPTION
## Changes

- Instead of returning 404 when a get request to ```/api/companies``` has no matches, return 200 with an empty ```data``` array

## Testing

How did you confirm your changes work? (Automated tests, manual verification, etc.)

- Manual testing with Postman

## Tracking

Resolves #51 
